### PR TITLE
Allow newer versions of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "rollbar": "^2.3.9"
   },
   "engines": {
-    "node": "9.2.1"
+    "node": ">=9.2.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Prevents the error (Yarn):
The engine "node" is incompatible with this module. Expected version "9.2.1". Got "XX.XX.X"

Related to #10 