### PR TITLE
fixed non http/https paths support

### DIFF
--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -91,9 +91,17 @@ UI.nodes.secondarySection
 UI.nodes.corsItForm.addEventListener('submit', (e) => {
   e.preventDefault();
 
+  function addProtocol(url) {
+    if (!/^(f|ht)tps?:\/\//i.test(url)) {
+      url = "https://" + url;
+    }
+    return url;
+  }
+
   UI.nodes.secondarySection
           .querySelector('#your-domain')
-          .textContent = UI.nodes.corsItContent.value.trim();
+          .textContent = addProtocol(UI.nodes.corsItContent.value.trim());
+
   
   UI.nodes.secondarySection
             .querySelectorAll('.solid-text, .shadow-text')


### PR DESCRIPTION
If user write `google.com`, the page add protocol **https** 

Result: **`https://google.com`**

If the url has `http protocol`. The url doesn't change.